### PR TITLE
Add 'main' attribute enabling webpack support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "type": "git",
     "url": "https://github.com/fastly/epoch.git"
   },
+  "main": "epoch.min.js",
   "dependencies": {
     "d3": "^3.4.13"
   },


### PR DESCRIPTION
Webpack needs a 'main' attribute in order to find the correct source file.