### PR TITLE
Fix bower.json main declaration

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,8 +3,8 @@
   "description": "A general purpose, real-time visualization library.",
   "version": "0.6.0",
   "main": [
-    "/epoch.min.js",
-    "/epoch.min.css"
+    "epoch.min.js",
+    "epoch.min.css"
   ],
   "license": "MIT",
   "ignore": [


### PR DESCRIPTION
The `main` declaration in `bower.json` currently uses absolute paths for some reason, which breaks major bower tools such as main-bower-files.

This PR removes the initial path slash, as recommended in the [bower.json spec](https://github.com/bower/bower.json-spec#main).