### PR TITLE
Add d3 dependency to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,5 +31,8 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/fastly/epoch.git"
+  },
+  "dependencies": {
+    "d3": "^3.4.13"
   }
 }


### PR DESCRIPTION
Bower is most useful when dependencies are defined, this adds the d3 dependency (just like in package.json) to the bower.json file.