### PR TITLE
Fixes #159; Update `node-sass` NPM Package

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "d3": "^3.4.13"
   },
   "devDependencies": {
-    "coffee-script": "^1.6.3",
-    "node-minify": "^0.7.5",
-    "codo": "^2.0.8",
-    "node-sass": "^0.9.3",
-    "mocha": "^1.18.2",
-    "xmlhttprequest": "^1.6.0",
+    "coffee-script": "^1.10.0",
+    "node-minify": "^1.2.1",
+    "codo": "^2.0.11",
+    "node-sass": "^3.3.3",
+    "mocha": "^2.3.3",
+    "xmlhttprequest": "^1.7.0",
     "jsdom": "^0.11.1",
-    "chai": "^1.9.1"
+    "chai": "^3.3.0"
   }
 }


### PR DESCRIPTION
The package was pretty out of date, seems they fixed the issue that was causing builds to hang. Also went through and updated other packages as I could (jsdom seemed to get weird, so I left it be).