### PR TITLE
Changed Codo Documentation Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .stamp*
-/doc/
+/codo-doc/
 /css/
 /js/
 /build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .stamp*
 /codo-doc/
+/doc/
 /css/
 /js/
 /build/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -106,15 +106,3 @@ gulp.task('clean', function (cb) {
     cb();
   });
 });
-
-/**
- * Generates codo documentation from the project's coffeescript source.
- */
-gulp.task('doc', function (cb) {
-  var command = [
-    './node_modules/.bin/codo --quiet --private',
-    '--name Epoch --readme README.md --title "Epoch Documentation"',
-    '--output #{dirs.doc} #{dirs.src} - LICENSE'
-  ].join('');
-  exec(command, cb);
-});

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
   },
   "scripts": {
     "build": "gulp build",
-    "test": "npm run build && mocha --recursive --compilers coffee:coffee-script/register tests/unit/"
+    "unit": "mocha --recursive --compilers coffee:coffee-script/register tests/unit/",
+    "test": "npm run build && npm run unit",
+    "codo": "./node_modules/.bin/codo --quiet --private --name Epoch --readme README.md --title 'Epoch Documentation' --output codo-doc src - LICENSE"
   }
 }


### PR DESCRIPTION
This is in anticipation of #189 and #190.

- Moved it out of the gulp pipeline (now strictly for builds)
- Moved it into the package.json scripts
- Changed the output directory to `codo-doc/`