### PR TITLE
Epoch.Formats.seconds test fails

### DIFF
--- a/tests/unit/core/format.coffee
+++ b/tests/unit/core/format.coffee
@@ -65,4 +65,4 @@ describe 'Epoch.Formats', ->
 
   describe 'seconds', ->
     it 'should return a well formatted date given a timestamp', ->
-      assert.equal Epoch.Formats.seconds(1404385979), '04:12:59 AM'
+      assert.match Epoch.Formats.seconds(1404385979), /\d{2}:\d{2}:\d{2} AM|PM/


### PR DESCRIPTION
Test fails when testing on a machine with timezone GMT+2. I think in this case checking correct format is enough.